### PR TITLE
Add semicolon to dyld_chained_fixups_header

### DIFF
--- a/fixups.py
+++ b/fixups.py
@@ -55,7 +55,7 @@ struct dyld_chained_fixups_header
     uint32_t imports_count;
     uint32_t imports_format;
     uint32_t symbols_format;
-}
+};
 """
 
 # Define necessary types


### PR DESCRIPTION
Without this Binary Ninja doesn't parse the type at all.